### PR TITLE
feat: implement board creation service and slugify title for new boards

### DIFF
--- a/src/controllers/boardController.js
+++ b/src/controllers/boardController.js
@@ -1,10 +1,11 @@
 import { StatusCodes } from 'http-status-codes'
+import { boardService } from '~/services/boardService'
 
 const createNew = async (req, res, next) => {
   try {
-    res.status(StatusCodes.CREATED).json({
-      message: 'Welcome to the boards route from controller'
-    })
+    const createdBoard = await boardService.createNew(req.body)
+
+    res.status(StatusCodes.CREATED).json(createdBoard)
   } catch (error) {
     next(error)
   }

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -1,0 +1,19 @@
+import { slugify } from '~/utils/formatters'
+
+const createNew = async reqBody => {
+  try {
+    const newBoard = {
+      ...reqBody,
+      slug: slugify(reqBody.title)
+    }
+
+    // always return in service
+    return newBoard
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
+export const boardService = {
+  createNew
+}

--- a/src/services/exampleService.js
+++ b/src/services/exampleService.js
@@ -1,5 +1,0 @@
-/**
- * Updated by trungquandev.com's author on August 17 2023
- * YouTube: https://youtube.com/@trungquandev
- * "A bit of fragrance clings to the hand that gives flowers!"
- */

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,13 @@
+const slugify = val => {
+  if (!val) return ''
+  return String(val)
+    .normalize('NFKD') // split accented characters into their base characters and diacritical marks
+    .replace(/[\u0300-\u036f]/g, '') // remove all the accents, which happen to be all in the \u03xx UNICODE block.
+    .trim() // trim leading or trailing whitespace
+    .toLowerCase() // convert to lowercase
+    .replace(/[^a-z0-9 -]/g, '') // remove non-alphanumeric characters
+    .replace(/\s+/g, '-') // replace spaces with hyphens
+    .replace(/-+/g, '-') // remove consecutive hyphens
+}
+
+export { slugify }


### PR DESCRIPTION
This pull request introduces a new board creation feature by adding a service layer and utility function, along with some minor code cleanup. The most important changes are:

### New Features:

* [`src/controllers/boardController.js`](diffhunk://#diff-0edfeca4e986dbddfd0d912ea316620bff59f47dfc0dee43cecd42449ad54c7eR2-R8): Modified the `createNew` method to use `boardService` for creating a new board and return the created board in the response.
* [`src/services/boardService.js`](diffhunk://#diff-5a3a2b0636a94de329b4848d1052a5c9cc3941543afc8cdab0a8ce4e05c7efb8R1-R19): Added a new `createNew` method in `boardService` to handle the creation of a new board, including generating a slug from the board title.
* [`src/utils/formatters.js`](diffhunk://#diff-3cd443b52db4eb49c7f8cf103b8a680ad00ea1120db7391a67696a23c0289fa6R1-R13): Introduced a `slugify` utility function to generate URL-friendly slugs from board titles.

### Code Cleanup:

* [`src/services/exampleService.js`](diffhunk://#diff-5a2bb02dd85c07fa73fba27034506959c8a576989b2312744494f8003a4004eeL1-L5): Removed outdated comments.