### PR TITLE
feat: add board, card, and column models with validation schemas

### DIFF
--- a/src/models/boardModel.js
+++ b/src/models/boardModel.js
@@ -1,0 +1,23 @@
+import Joi from 'joi'
+import { OBJECT_ID_RULE, OBJECT_ID_RULE_MESSAGE } from '~/utils/validators'
+
+// Define Collection (name & schema)
+const BOARD_COLLECTION_NAME = 'boards'
+const BOARD_COLLECTION_SCHEMA = Joi.object({
+  title: Joi.string().required().min(3).max(50).trim().strict(),
+  slug: Joi.string().required().min(3).trim().strict(),
+  description: Joi.string().required().min(3).max(256).trim().strict(),
+
+  columnOrderIds: Joi.array()
+    .items(Joi.string().pattern(OBJECT_ID_RULE).message(OBJECT_ID_RULE_MESSAGE))
+    .default([]),
+
+  createdAt: Joi.date().timestamp('javascript').default(Date.now),
+  updatedAt: Joi.date().timestamp('javascript').default(null),
+  _destroy: Joi.boolean().default(false)
+})
+
+export const boardModel = {
+  BOARD_COLLECTION_NAME,
+  BOARD_COLLECTION_SCHEMA
+}

--- a/src/models/cardModel.js
+++ b/src/models/cardModel.js
@@ -1,0 +1,27 @@
+import Joi from 'joi'
+import { OBJECT_ID_RULE, OBJECT_ID_RULE_MESSAGE } from '~/utils/validators'
+
+// Define Collection (name & schema)
+const CARD_COLLECTION_NAME = 'cards'
+const CARD_COLLECTION_SCHEMA = Joi.object({
+  boardId: Joi.string()
+    .required()
+    .pattern(OBJECT_ID_RULE)
+    .message(OBJECT_ID_RULE_MESSAGE),
+  columnId: Joi.string()
+    .required()
+    .pattern(OBJECT_ID_RULE)
+    .message(OBJECT_ID_RULE_MESSAGE),
+
+  title: Joi.string().required().min(3).max(50).trim().strict(),
+  description: Joi.string().optional(),
+
+  createdAt: Joi.date().timestamp('javascript').default(Date.now),
+  updatedAt: Joi.date().timestamp('javascript').default(null),
+  _destroy: Joi.boolean().default(false)
+})
+
+export const cardModel = {
+  CARD_COLLECTION_NAME,
+  CARD_COLLECTION_SCHEMA
+}

--- a/src/models/columnModel.js
+++ b/src/models/columnModel.js
@@ -1,0 +1,26 @@
+import Joi from 'joi'
+import { OBJECT_ID_RULE, OBJECT_ID_RULE_MESSAGE } from '~/utils/validators'
+
+// Define Collection (name & schema)
+const COLUMN_COLLECTION_NAME = 'columns'
+const COLUMN_COLLECTION_SCHEMA = Joi.object({
+  boardId: Joi.string()
+    .required()
+    .pattern(OBJECT_ID_RULE)
+    .message(OBJECT_ID_RULE_MESSAGE),
+  title: Joi.string().required().min(3).max(50).trim().strict(),
+
+  // Lưu ý các item trong mảng cardOrderIds là ObjectId nên cần thêm pattern cho chuẩn nhé, (lúc quay video số 57 mình quên nhưng sang đầu video số 58 sẽ có nhắc lại về cái này.)
+  cardOrderIds: Joi.array()
+    .items(Joi.string().pattern(OBJECT_ID_RULE).message(OBJECT_ID_RULE_MESSAGE))
+    .default([]),
+
+  createdAt: Joi.date().timestamp('javascript').default(Date.now),
+  updatedAt: Joi.date().timestamp('javascript').default(null),
+  _destroy: Joi.boolean().default(false)
+})
+
+export const columnModel = {
+  COLUMN_COLLECTION_NAME,
+  COLUMN_COLLECTION_SCHEMA
+}

--- a/src/models/exampleModel.js
+++ b/src/models/exampleModel.js
@@ -1,5 +1,0 @@
-/**
- * Updated by trungquandev.com's author on August 17 2023
- * YouTube: https://youtube.com/@trungquandev
- * "A bit of fragrance clings to the hand that gives flowers!"
- */

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,0 +1,3 @@
+export const OBJECT_ID_RULE = /^[0-9a-fA-F]{24}$/
+export const OBJECT_ID_RULE_MESSAGE =
+  'Your string fails to match the Object Id pattern!'


### PR DESCRIPTION
This pull request introduces schema validation for the `boardModel`, `cardModel`, and `columnModel` using Joi, and adds utility constants for object ID validation. Additionally, it removes a comment from the `exampleModel` file.

Schema validation:

* [`src/models/boardModel.js`](diffhunk://#diff-97dc5097d6d5d3446d69849ed55f9ef5e9b84aed0688261bc307eba55f3796f7R1-R23): Added Joi schema validation for the board model, including fields like `title`, `slug`, `description`, `columnOrderIds`, `createdAt`, `updatedAt`, and `_destroy`.
* [`src/models/cardModel.js`](diffhunk://#diff-599e793405c5549f1c2e30fa337c0575213ba98509904a90cf875e8a5b268b55R1-R27): Added Joi schema validation for the card model, including fields like `boardId`, `columnId`, `title`, `description`, `createdAt`, `updatedAt`, and `_destroy`.
* [`src/models/columnModel.js`](diffhunk://#diff-3282c8c3a2754e5c1e27bb82a87fae83d5ca607e2e6524bec6cc34bc7230358cR1-R26): Added Joi schema validation for the column model, including fields like `boardId`, `title`, `cardOrderIds`, `createdAt`, `updatedAt`, and `_destroy`.

Utility constants:

* [`src/utils/validators.js`](diffhunk://#diff-367972a755cd6acd3b94d278ed44a9082fa849feaf356e07768f26e3a2d4f3c5R1-R3): Added `OBJECT_ID_RULE` and `OBJECT_ID_RULE_MESSAGE` constants for validating object IDs.

Comment removal:

* [`src/models/exampleModel.js`](diffhunk://#diff-a1ef78bbe73526fece1703c0a97b0617ae5a3a723820f7aebfa06e874bf892f7L1-L5): Removed an author comment.