### PR TITLE
feat: add create and find board methods to board model and update service to return created board

### DIFF
--- a/src/models/boardModel.js
+++ b/src/models/boardModel.js
@@ -1,4 +1,6 @@
 import Joi from 'joi'
+import { ObjectId } from 'mongodb'
+import { GET_DB } from '~/config/mongodb'
 import { OBJECT_ID_RULE, OBJECT_ID_RULE_MESSAGE } from '~/utils/validators'
 
 // Define Collection (name & schema)
@@ -17,7 +19,33 @@ const BOARD_COLLECTION_SCHEMA = Joi.object({
   _destroy: Joi.boolean().default(false)
 })
 
+const createNew = async data => {
+  try {
+    const createdBoard = await GET_DB()
+      .collection(BOARD_COLLECTION_NAME)
+      .insertOne(data)
+
+    return createdBoard
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
+const findOneById = async id => {
+  try {
+    const board = await GET_DB()
+      .collection(BOARD_COLLECTION_NAME)
+      .findOne({ _id: id })
+
+    return board
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
 export const boardModel = {
   BOARD_COLLECTION_NAME,
-  BOARD_COLLECTION_SCHEMA
+  BOARD_COLLECTION_SCHEMA,
+  createNew,
+  findOneById
 }

--- a/src/services/boardService.js
+++ b/src/services/boardService.js
@@ -1,3 +1,4 @@
+import { boardModel } from '~/models/boardModel'
 import { slugify } from '~/utils/formatters'
 
 const createNew = async reqBody => {
@@ -7,8 +8,12 @@ const createNew = async reqBody => {
       slug: slugify(reqBody.title)
     }
 
+    const createdBoard = await boardModel.createNew(newBoard)
+
+    const getNewBoard = await boardModel.findOneById(createdBoard.insertedId)
+
     // always return in service
-    return newBoard
+    return getNewBoard
   } catch (error) {
     throw new Error(error)
   }


### PR DESCRIPTION
This pull request introduces several significant changes to the board model and service to support creating and retrieving boards from the database. The most important changes include adding database interaction functions to the board model and updating the board service to use these new functions.

### Database interaction functions:

* [`src/models/boardModel.js`](diffhunk://#diff-97dc5097d6d5d3446d69849ed55f9ef5e9b84aed0688261bc307eba55f3796f7R22-R50): Added `createNew` function to insert a new board into the database and `findOneById` function to retrieve a board by its ID.

### Board service updates:

* [`src/services/boardService.js`](diffhunk://#diff-5a3a2b0636a94de329b4848d1052a5c9cc3941543afc8cdab0a8ce4e05c7efb8R11-R16): Updated the `createNew` function to use `boardModel.createNew` for inserting a new board and `boardModel.findOneById` for retrieving the newly created board.

### Import updates:

* [`src/models/boardModel.js`](diffhunk://#diff-97dc5097d6d5d3446d69849ed55f9ef5e9b84aed0688261bc307eba55f3796f7R2-R3): Added imports for `ObjectId` from `mongodb` and `GET_DB` from `~/config/mongodb`.
* [`src/services/boardService.js`](diffhunk://#diff-5a3a2b0636a94de329b4848d1052a5c9cc3941543afc8cdab0a8ce4e05c7efb8R1): Added import for `boardModel` from `~/models/boardModel`.